### PR TITLE
fixed import statement bug

### DIFF
--- a/lunabot_control/firmware/teensy_main/teensy_main.ino
+++ b/lunabot_control/firmware/teensy_main/teensy_main.ino
@@ -1,27 +1,27 @@
 // include ROS and all messages
+#include "ros.h"
 #include <lunabot_msgs/RobotEffort.h>
 #include <robot.hpp>
-#include <ros.h>
 
 ros::NodeHandle nh;
 
 void effort_cb(const lunabot_msgs::RobotEffort &effort) {
-    actuation::cb(effort.lead_screw, effort.lin_act);
-    drivetrain::cb(effort.left_drive, effort.right_drive);
-    deposition::cb(effort.deposit);
-    excavation::cb(effort.excavate);
+  actuation::cb(effort.lead_screw, effort.lin_act);
+  drivetrain::cb(effort.left_drive, effort.right_drive);
+  deposition::cb(effort.deposit);
+  excavation::cb(effort.excavate);
 }
 
 ros::Subscriber<lunabot_msgs::RobotEffort> effort_sub("/effort", effort_cb);
 
 void setup() {
-    STMotorInterface::init_serial(ST_SERIAL, ST_BAUD_RATE);
-    nh.initNode();
-    nh.subscribe(effort_sub);
+  STMotorInterface::init_serial(ST_SERIAL, ST_BAUD_RATE);
+  nh.initNode();
+  nh.subscribe(effort_sub);
 }
 
 void loop() {
-    nh.spinOnce();
-    actuation::run();
-    delay(10);
+  nh.spinOnce();
+  actuation::run();
+  delay(10);
 }

--- a/lunabot_msgs/msg/RobotCmd.msg
+++ b/lunabot_msgs/msg/RobotCmd.msg
@@ -1,2 +1,0 @@
-Header header
-geometry_msgs/Twist cmd_vel


### PR DESCRIPTION
- Arduino linker toolchain cannot find ros message includes without importing ros.h first, resulting in an obscure header not found error, clang linter ordered the includes in the wrong way resulting in the error
- removes stale ROS messages