### PR TITLE
Undid change to MPC publishing 0 vel when no path

### DIFF
--- a/lunabot_control/src/mpc.cpp
+++ b/lunabot_control/src/mpc.cpp
@@ -271,7 +271,6 @@ bool comparator(std::pair<Eigen::MatrixXd, double> a, std::pair<Eigen::MatrixXd,
 void MPC::calculate_velocity() {
   SWRI_PROFILE("calculate-velocity");
   if (this->robot_pos_.empty() || this->path_.empty() || !this->enabled_) {
-    MPC::publish_velocity_(0, 0);
     return;
   }
   int horizon_length = this->horizon_length_;


### PR DESCRIPTION
"Oops"

This change was designed to make the robot stop when it lost the path (instead of past behavior, in which the velocity stays set).
But by constantly publishing 0 cmd_vel, it made it so rqt was not effective and likely not manual control either.

To check that this functions: launch sim and use rqt to steer at any velocity. Before, it should hesitate a lot/move little. Now should be back to normal.

Note that a fix for the original problem still needs to be worked on. Perhaps a bit better than what I just tried.