### PR TITLE
User/raghavauppuluri13/protobuf size checker

### DIFF
--- a/lunabot_embedded/CMakeLists.txt
+++ b/lunabot_embedded/CMakeLists.txt
@@ -133,3 +133,14 @@ target_link_libraries(${PROJECT_NAME}_teensy_driver_node
   ${catkin_LIBRARIES}
 )
 
+add_executable(${PROJECT_NAME}_test_pb src/test_pb.cpp
+  src/pb_common.c 
+  src/pb_encode.c 
+  src/pb_decode.c 
+  src/RobotMsgs.pb.c 
+)
+set_target_properties(${PROJECT_NAME}_test_pb PROPERTIES OUTPUT_NAME test_pb PREFIX "")
+add_dependencies(${PROJECT_NAME}_test_pb ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME}_test_pb
+  ${catkin_LIBRARIES}
+)

--- a/lunabot_embedded/CMakeLists.txt
+++ b/lunabot_embedded/CMakeLists.txt
@@ -133,14 +133,20 @@ target_link_libraries(${PROJECT_NAME}_teensy_driver_node
   ${catkin_LIBRARIES}
 )
 
-add_executable(${PROJECT_NAME}_test_pb src/test_pb.cpp
-  src/pb_common.c 
-  src/pb_encode.c 
-  src/pb_decode.c 
-  src/RobotMsgs.pb.c 
-)
-set_target_properties(${PROJECT_NAME}_test_pb PROPERTIES OUTPUT_NAME test_pb PREFIX "")
-add_dependencies(${PROJECT_NAME}_test_pb ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(${PROJECT_NAME}_test_pb
-  ${catkin_LIBRARIES}
-)
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(GTest REQUIRED)
+  include_directories(${GTEST_INCLUDE_DIRS})
+  ## Add the Google Test to the testing framework of catkin
+  catkin_add_gtest(${PROJECT_NAME}_test_protobuf 
+    src/test_pb.cpp
+    src/pb_common.c 
+    src/pb_encode.c 
+    src/pb_decode.c 
+    src/RobotMsgs.pb.c  
+  )
+  target_link_libraries(${PROJECT_NAME}_test_protobuf
+    ${catkin_LIBRARIES}
+    ${GTEST_LIBRARIES}
+  )
+endif()

--- a/lunabot_embedded/src/test_pb.cpp
+++ b/lunabot_embedded/src/test_pb.cpp
@@ -1,0 +1,53 @@
+#include <ctime>
+#include <iostream>
+#include <lunabot_embedded/sensor_proc.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+
+extern "C" {
+#include "RobotMsgs.pb.h"
+#include "hid.h"
+#include "pb_decode.h"
+#include "pb_encode.h"
+}
+
+using namespace std;
+
+RobotSensors state = RobotSensors_init_zero;
+RobotEffort effort = RobotEffort_init_zero;
+
+int main(int argc, char **argv) {
+
+  state.lead_screw_curr = 65535;
+  state.act_right_curr = 65535;
+  state.dep_curr = 65535;
+  state.exc_curr = 65535;
+  state.drive_left_curr = 65535;
+  state.drive_right_curr = 65535;
+
+  state.drive_left_ang = DEG2RAD(360.0);
+  state.drive_right_ang = DEG2RAD(360.0);
+  state.exc_ang = DEG2RAD(360.0);
+  state.uwb_dist_0 = 10.0;
+  state.uwb_dist_1 = 10.0;
+  state.uwb_dist_2 = 10.0;
+
+  effort.lin_act = 126;
+  effort.left_drive = 126;
+  effort.right_drive = 126;
+  effort.excavate = 126;
+  effort.deposit = 126;
+  size_t sensors_size;
+  size_t effort_size;
+  bool res = pb_get_encoded_size(&sensors_size, RobotSensors_fields, &state);
+
+  cout << "sensors nanopb msg encoding success: " << res << endl;
+  res = pb_get_encoded_size(&effort_size, RobotEffort_fields, &effort);
+  cout << "effort nanopb msg encoding success: " << res << endl;
+
+  cout << "sensors nanopb msg size (bytes): " << sensors_size << endl;
+  cout << "effort nanopb msg size (bytes): " << effort_size << endl;
+}

--- a/lunabot_embedded/src/test_pb.cpp
+++ b/lunabot_embedded/src/test_pb.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <ctime>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <lunabot_embedded/sensor_proc.h>
 #include <stdarg.h>
@@ -17,10 +18,9 @@ extern "C" {
 
 using namespace std;
 
-RobotSensors state = RobotSensors_init_zero;
-RobotEffort effort = RobotEffort_init_zero;
-
-int main(int argc, char **argv) {
+TEST(ProtobufTestSuite, size_check) {
+  RobotSensors state = RobotSensors_init_zero;
+  RobotEffort effort = RobotEffort_init_zero;
   state.lead_screw_curr = 65535;
   state.act_right_curr = 65535;
   state.dep_curr = 65535;
@@ -43,13 +43,18 @@ int main(int argc, char **argv) {
   size_t sensors_size = 0;
   size_t effort_size = 0;
   bool res = pb_get_encoded_size(&sensors_size, RobotSensors_fields, &state);
-  assert(res);
+  ASSERT_TRUE(res);
   res = pb_get_encoded_size(&effort_size, RobotEffort_fields, &effort);
-  assert(res);
+  ASSERT_TRUE(res);
   cout << "sensors nanopb msg size (bytes): " << sensors_size << endl;
   cout << "effort nanopb msg size (bytes): " << effort_size << endl;
   // rawhid can transfer up to 64 bytes each way at 1khz, this file sanity checks this:
   // https://www.pjrc.com/teensy/rawhid.html
-  assert(sensors_size < 64);
-  assert(effort_size < 64);
+  ASSERT_TRUE(sensors_size < 64);
+  ASSERT_TRUE(effort_size < 64);
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/lunabot_embedded/src/test_pb.cpp
+++ b/lunabot_embedded/src/test_pb.cpp
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <ctime>
 #include <iostream>
 #include <lunabot_embedded/sensor_proc.h>
@@ -20,7 +21,6 @@ RobotSensors state = RobotSensors_init_zero;
 RobotEffort effort = RobotEffort_init_zero;
 
 int main(int argc, char **argv) {
-
   state.lead_screw_curr = 65535;
   state.act_right_curr = 65535;
   state.dep_curr = 65535;
@@ -40,14 +40,16 @@ int main(int argc, char **argv) {
   effort.right_drive = 126;
   effort.excavate = 126;
   effort.deposit = 126;
-  size_t sensors_size;
-  size_t effort_size;
+  size_t sensors_size = 0;
+  size_t effort_size = 0;
   bool res = pb_get_encoded_size(&sensors_size, RobotSensors_fields, &state);
-
-  cout << "sensors nanopb msg encoding success: " << res << endl;
+  assert(res);
   res = pb_get_encoded_size(&effort_size, RobotEffort_fields, &effort);
-  cout << "effort nanopb msg encoding success: " << res << endl;
-
+  assert(res);
   cout << "sensors nanopb msg size (bytes): " << sensors_size << endl;
   cout << "effort nanopb msg size (bytes): " << effort_size << endl;
+  // rawhid can transfer up to 64 bytes each way at 1khz, this file sanity checks this:
+  // https://www.pjrc.com/teensy/rawhid.html
+  assert(sensors_size < 64);
+  assert(effort_size < 64);
 }


### PR DESCRIPTION
we use [nanopb/protobuf](https://jpa.kapsi.fi/nanopb/docs/concepts.html) standard for comms between teensy and jetson. makes sure that the protobuf state and effort messages are less than max length allowed by RawHID. 

Uses Gtest, so will run with CI/CD. Run using `catkin test` or `catkin test lunabot_embedded` for only this package's tests.